### PR TITLE
no more horizontal scroll bar

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -1,0 +1,5 @@
+html,body {
+    margin:0;
+    padding:0;
+    overflow-x:hidden;
+}


### PR DESCRIPTION
Added code to main.css in order to fix the extra space issue we had on the right side of the home page.
The code was added to the main.css file in order to be applied to the entire app.
By deleting the extra space, the horizontal scroll bar is automatically removed as well.
NOTE: There is still a gap between the navbar and the right side of the page. This issue will be fixed in a pr dedicated to it.

           modified:   app/assets/stylesheets/main.css

